### PR TITLE
Also depend on gobject-2.0 via pkg-config

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,9 @@ library:
   include-dirs: include
   c-sources:
   - csrc/pango_log_attr.c
-  pkg-config-dependencies: pangocairo
+  pkg-config-dependencies:
+  - pangocairo
+  - gobject-2.0
 
 tests:
   simple-pango-test:

--- a/simple-pango.cabal
+++ b/simple-pango.cabal
@@ -73,6 +73,7 @@ library
       csrc/pango_log_attr.c
   pkgconfig-depends:
       pangocairo
+    , gobject-2.0
   build-depends:
       array
     , base >=4.7 && <5


### PR DESCRIPTION
Since simple-pango uses g_object_unref, provided by gobject, it also needs to depend on it. Omitting this dependency works for some versions of pangocairo where the pkg-config file propagates gobject, but this is not always the case, causing linker failures.